### PR TITLE
New socket control model, based on router events. "If socket is start…

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/angular-16-test2/browser",
+            "outputPath": "dist/angular-meta-trader/browser",
             "index": "src/index.html",
             "main": "src/main.browser.ts",
             "polyfills": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@ngrx/effects": "^16.0.0",
         "@ngrx/entity": "^16.0.0",
         "@ngrx/eslint-plugin": "^16.0.0",
+        "@ngrx/router-store": "^16.0.0",
         "@ngrx/store": "^16.0.0",
         "@ngrx/store-devtools": "^16.0.0",
         "@nguniversal/express-engine": "^16.0.1",
@@ -4186,6 +4187,21 @@
       "peerDependencies": {
         "eslint": ">=8.0.0",
         "typescript": ">=4.4.0"
+      }
+    },
+    "node_modules/@ngrx/router-store": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/router-store/-/router-store-16.0.0.tgz",
+      "integrity": "sha512-i36reUxFSkpnEr01yZufe8H5J6Na0q/5Ul3HmT1HSG5cw0y2xIHWk2MpvCLIJjr3WeGSLvVpkQUYEdkkgmJOdw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.0.0",
+        "@angular/core": "^16.0.0",
+        "@angular/router": "^16.0.0",
+        "@ngrx/store": "16.0.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
       }
     },
     "node_modules/@ngrx/schematics": {
@@ -24124,6 +24140,14 @@
         "eslint-etc": "^5.1.0",
         "semver": "^7.3.5",
         "strip-json-comments": "3.1.1"
+      }
+    },
+    "@ngrx/router-store": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/router-store/-/router-store-16.0.0.tgz",
+      "integrity": "sha512-i36reUxFSkpnEr01yZufe8H5J6Na0q/5Ul3HmT1HSG5cw0y2xIHWk2MpvCLIJjr3WeGSLvVpkQUYEdkkgmJOdw==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "@ngrx/schematics": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@ngrx/effects": "^16.0.0",
     "@ngrx/entity": "^16.0.0",
     "@ngrx/eslint-plugin": "^16.0.0",
+    "@ngrx/router-store": "^16.0.0",
     "@ngrx/store": "^16.0.0",
     "@ngrx/store-devtools": "^16.0.0",
     "@nguniversal/express-engine": "^16.0.1",

--- a/src/app/core/facades/open-position.facade.ts
+++ b/src/app/core/facades/open-position.facade.ts
@@ -6,24 +6,12 @@ import {
   selectOpenPositionsIds,
   selectTotalOpenPositions,
 } from 'app-core/store/selectors/open-positions.selectors';
-import {
-  initialOpenPositionsLoad,
-  startOpenPositionsStream,
-} from 'app-core/store/actions/open-position.actions';
 
 @Injectable({
   providedIn: 'root',
 })
 export class OpenPositionFacade {
   constructor(private store: Store) {}
-
-  loadInitialOpenPositions() {
-    this.store.dispatch(initialOpenPositionsLoad());
-  }
-
-  startOpenPositionsStream() {
-    this.store.dispatch(startOpenPositionsStream());
-  }
 
   getSelectedOpenPositions() {
     return this.store.pipe(select(selectOpenPositionsIds));

--- a/src/app/core/facades/rates.facade.ts
+++ b/src/app/core/facades/rates.facade.ts
@@ -2,10 +2,6 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AppState } from 'app-core/models/general-state';
 import {
-  initialRatesLoad,
-  startRatesStream,
-} from 'app-core/store/actions/rate.actions';
-import {
   selectAllRates,
   selectRatesEntities,
   selectRatesIds,
@@ -17,14 +13,6 @@ import {
 })
 export class RatesFacade {
   constructor(private store: Store<AppState>) {}
-
-  loadInitialRates() {
-    this.store.dispatch(initialRatesLoad());
-  }
-
-  startRatesStream() {
-    this.store.dispatch(startRatesStream());
-  }
 
   getSelectedRate() {
     return this.store.select(selectRatesIds);

--- a/src/app/core/models/configuration.ts
+++ b/src/app/core/models/configuration.ts
@@ -1,4 +1,6 @@
 export interface ConfigurationState {
   realTimeRatesList: string[];
   websocketConnected: boolean;
+  openPositionStreamStarted: boolean;
+  ratesStreamStarted: boolean;
 }

--- a/src/app/core/models/general-state.ts
+++ b/src/app/core/models/general-state.ts
@@ -2,10 +2,13 @@ import { ConfigurationState } from 'app-core/models/configuration';
 import { RateState } from 'app-core/models/rate.model';
 import { OpenPositionsState } from 'app-core/models/open-position.model';
 import { ChartsState } from 'app-core/models/chart.model';
+import { RouterReducerState } from '@ngrx/router-store';
+import { RouterStateUrl } from 'app-core/models/router-state.model';
 
 export interface AppState {
   configuration: ConfigurationState;
   rates: RateState;
   OpenPosition: OpenPositionsState;
   Charts: ChartsState;
+  router: RouterReducerState<RouterStateUrl>;
 }

--- a/src/app/core/models/router-state.model.ts
+++ b/src/app/core/models/router-state.model.ts
@@ -1,0 +1,7 @@
+import {Params} from "@angular/router";
+
+export interface RouterStateUrl {
+  url: string;
+  params: Params;
+  queryParams: Params;
+}

--- a/src/app/core/services/data.service.ts
+++ b/src/app/core/services/data.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Optional } from '@angular/core';
 import { map, filter, take } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import {Observable, of} from 'rxjs';
 import { BaseRate, Rate } from '../models/rate.model';
 import { BaseOpenPosition, OpenPosition } from '../models/open-position.model';
 import { ratesList } from '../../../environments/environment';
-import { BaseSocketData, SocketMessage} from '../models/socket-message';
+import { BaseSocketData, SocketMessage } from '../models/socket-message';
 import { Chart, BaseChart } from '../models/chart.model';
 import {
   convertChart,
@@ -21,11 +21,18 @@ export class DataService {
 
   constructor(@Optional() private socketService: SocketService) {}
 
-  // startWebSocket() {
-  //   if (this.socketService) {
-  //     this.socketService.startWebSocket();
-  //   }
-  // }
+  startWebSocket() {
+    if (this.socketService) {
+      this.socketService.startWebSocket();
+    }
+  }
+  checkIsSocketIsConnected(){
+    if (this.socketService) {
+      return this.socketService.startedSocket
+    } else {
+      return of(false);
+    }
+  }
 
   sentMessageToSocket(event: string, data?: string | string[]) {
     if (this.socketService) {

--- a/src/app/core/store/actions/open-position.actions.ts
+++ b/src/app/core/store/actions/open-position.actions.ts
@@ -14,6 +14,10 @@ export const startOpenPositionsStream = createAction(
   '[OpenPosition/API] Start Open Position Stream'
 );
 
+export const stopOpenPositionsStream = createAction(
+  '[OpenPosition/API] Stop Open Position Stream'
+);
+
 export const updateOpenPositionsFromStreamSuccess = createAction(
   '[OpenPosition/API] Update Open Position From Stream Success',
   props<{ openPositions: OpenPosition[] }>()

--- a/src/app/core/store/actions/rate.actions.ts
+++ b/src/app/core/store/actions/rate.actions.ts
@@ -14,6 +14,10 @@ export const startRatesStream = createAction(
   '[Rate/API] Start Rates Stream'
 );
 
+export const stopRatesStream = createAction(
+  '[Rate/API] Stop Rates Stream'
+);
+
 export const updateRatesFromStreamSuccess = createAction(
   '[Rate/API] Update Rates From Stream Success',
   props<{ rates: Rate[] }>()

--- a/src/app/core/store/core-store.module.ts
+++ b/src/app/core/store/core-store.module.ts
@@ -1,5 +1,5 @@
 import { ActionReducerMap, MetaReducer, Store, StoreModule } from '@ngrx/store';
-import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule, TransferState } from '@angular/core';
 import * as Configuration from './reducers/configuration.reducer';
 import * as Rate from './reducers/rate.reducer';
 import * as OpenPosition from './reducers/open-position.reducer';
@@ -10,15 +10,20 @@ import { ConfigurationEffects } from 'app-core/store/effects/configuration.effec
 import { RatesEffects } from 'app-core/store/effects/rates.effects';
 import { OpenPositionsEffects } from 'app-core/store/effects/open-positions.effects';
 import { ChartsEffects } from 'app-core/store/effects/charts.effects';
-import { TransferState } from '@angular/core';
-import { setStateOnBrowser, stateTransferFromServerToBrowser} from '../utils/state-transfer.helper';
+import {
+  setStateOnBrowser,
+  stateTransferFromServerToBrowser,
+} from '../utils/state-transfer.helper';
 import { storeDevtoolsModule } from '../../replacements/store-devtools.module';
+import { routerReducer, StoreRouterConnectingModule } from '@ngrx/router-store';
+import {CustomSerializer} from "app-core/utils/custom-route.serializer";
 
 export const reducers: ActionReducerMap<AppState> = {
   configuration: Configuration.reducer,
   rates: Rate.reducer,
   OpenPosition: OpenPosition.reducer,
   Charts: Charts.reducer,
+  router: routerReducer,
 };
 
 const metaReducers: MetaReducer<AppState>[] = [setStateOnBrowser];
@@ -32,6 +37,9 @@ const metaReducers: MetaReducer<AppState>[] = [setStateOnBrowser];
       OpenPositionsEffects,
       ChartsEffects,
     ]),
+    StoreRouterConnectingModule.forRoot({
+      serializer: CustomSerializer
+    }),
     storeDevtoolsModule
   ],
   providers: [

--- a/src/app/core/store/effects/configuration.effects.ts
+++ b/src/app/core/store/effects/configuration.effects.ts
@@ -1,13 +1,42 @@
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import {Inject, Injectable, isDevMode, PLATFORM_ID} from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { Actions, createEffect, ROOT_EFFECTS_INIT } from '@ngrx/effects';
-import { ofType } from '@ngrx/effects';
+import {
+  Actions,
+  createEffect,
+  ROOT_EFFECTS_INIT,
+  ofType,
+} from '@ngrx/effects';
+
 import {
   loadConnectWebsockets,
   loadConnectWebsocketsSuccess,
 } from 'app-core/store/actions/configuration.actions';
-import { concatMap, map, tap, filter } from 'rxjs/operators';
+import {
+  concatMap,
+  map,
+  filter,
+  take,
+  withLatestFrom,
+  tap,
+} from 'rxjs/operators';
 import { DataService } from 'app-core/services/data.service';
+import { select, Store } from '@ngrx/store';
+import {
+  openPositionStreamStatus,
+  ratesStreamStatus,
+  socketStatus
+} from 'app-core/store/selectors/configuration.selectors';
+
+import { routerNavigationAction } from '@ngrx/router-store';
+import { mapToPayload } from 'app-core/utils/rxjs.helper';
+import {
+  initialRatesLoad,
+  stopRatesStream
+} from "app-core/store/actions/rate.actions";
+import {
+  initialOpenPositionsLoad,
+  stopOpenPositionsStream
+} from "app-core/store/actions/open-position.actions";
 
 const ACTION_TYPE = 'Transfer State from SSR';
 
@@ -16,21 +45,74 @@ export class ConfigurationEffects {
   constructor(
     private actions$: Actions,
     private dataService: DataService,
+    private store: Store,
+
     @Inject(PLATFORM_ID) private platformId: string
   ) {}
 
-  init$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(ACTION_TYPE),
-      filter(() => isPlatformBrowser(this.platformId)),
-      concatMap(() => [loadConnectWebsockets()])
-    );
-  });
+  initDev$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ROOT_EFFECTS_INIT),
+      filter(
+        () => isPlatformBrowser(this.platformId) && isDevMode()
+      ),
+      map(loadConnectWebsockets)
+    )
+  );
 
-  loadWebSocket$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(ROOT_EFFECTS_INIT, loadConnectWebsockets),
-      map(loadConnectWebsocketsSuccess)
-    );
-  });
+  initProd$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ACTION_TYPE),
+      filter(
+        () => isPlatformBrowser(this.platformId) && !isDevMode()
+      ),
+      map(loadConnectWebsockets)
+    )
+  );
+
+  loadWebSocket$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(loadConnectWebsockets),
+      filter(() => isPlatformBrowser(this.platformId)),
+      withLatestFrom(this.store.pipe(select(socketStatus))),
+      filter(([, status]) => !status),
+      tap(() => {
+        this.dataService.startWebSocket();
+      }),
+      concatMap(() => this.dataService.checkIsSocketIsConnected().pipe(
+          filter(x => !!x),
+          take(1),
+          map(loadConnectWebsocketsSuccess)
+        )
+    )
+    ));
+
+  startRatesOpenPositionsStream$ = createEffect(() =>
+      this.actions$.pipe(
+      ofType(routerNavigationAction),
+        filter(() => isPlatformBrowser(this.platformId)),
+        mapToPayload(),
+        map(val => val.routerState),
+        filter(val => val.url === '/dashboard'),
+        concatMap(() =>  this.store.pipe(
+          select(socketStatus),
+          filter(status => !!status),
+          take(1),
+          concatMap(() => [initialRatesLoad(), initialOpenPositionsLoad()])
+        )
+      )
+      )
+  );
+  stopRatesOpenPositionsStream$ = createEffect(() =>
+      this.actions$.pipe(
+        ofType(routerNavigationAction),
+        filter(() => isPlatformBrowser(this.platformId)),
+        mapToPayload(),
+        map((val) => val.routerState),
+        filter((val) => val.url !== '/dashboard'),
+        withLatestFrom(this.store.pipe(select(ratesStreamStatus)),this.store.pipe(select(openPositionStreamStatus))),
+        filter(([,ratesStatus,positionsStatus]) => !!ratesStatus && !!positionsStatus),
+        concatMap(() => [stopRatesStream(),stopOpenPositionsStream()])
+      )
+  );
 }

--- a/src/app/core/store/reducers/configuration.reducer.ts
+++ b/src/app/core/store/reducers/configuration.reducer.ts
@@ -1,6 +1,8 @@
 import { createReducer, on } from '@ngrx/store';
 import { ConfigurationState } from 'app-core/models/configuration';
 import { loadConnectWebsocketsSuccess } from 'app-core/store/actions/configuration.actions';
+import { startRatesStream, stopRatesStream } from "app-core/store/actions/rate.actions";
+import {startOpenPositionsStream, stopOpenPositionsStream} from "app-core/store/actions/open-position.actions";
 
 export const initialState: ConfigurationState = {
   realTimeRatesList: [
@@ -23,12 +25,40 @@ export const initialState: ConfigurationState = {
     'NZDUSD',
   ],
   websocketConnected: false,
+  openPositionStreamStarted: false,
+  ratesStreamStarted: false
 };
 
 export const reducer = createReducer(
   initialState,
-  on(loadConnectWebsocketsSuccess, (state) => ({
-    ...state,
-    websocketConnected: true,
-  }))
+  on(loadConnectWebsocketsSuccess, (state) =>
+      ({
+      ...state,
+      websocketConnected: true,
+    })
+  ),
+  on(startRatesStream, state =>
+    ({
+      ...state,
+      ratesStreamStarted: true
+    })
+  ),
+  on(stopRatesStream, state =>
+    ({
+      ...state,
+      ratesStreamStarted: false
+    })
+  ),
+  on(startOpenPositionsStream, state =>
+    ({
+      ...state,
+      openPositionStreamStarted: true
+    })
+  ),
+  on(stopOpenPositionsStream, state =>
+    ({
+      ...state,
+      openPositionStreamStarted: false
+    })
+  )
 );

--- a/src/app/core/store/reducers/rate.reducer.ts
+++ b/src/app/core/store/reducers/rate.reducer.ts
@@ -28,10 +28,10 @@ export const reducer = createReducer(
   initialState,
   on(addRate, (state, action) => adapter.addOne(action.rate, state)),
   on(upsertRate, (state, action) => adapter.upsertOne(action.rate, state)),
-  on(addRates, initialRatesLoadSuccess, (state, action) =>
+  on(addRates, (state, action) =>
     adapter.addMany(action.rates, state)
   ),
-  on(upsertRates, updateRatesFromStreamSuccess, (state, action) =>
+  on(upsertRates, initialRatesLoadSuccess, updateRatesFromStreamSuccess, (state, action) =>
     adapter.upsertMany(action.rates, state)
   ),
   on(updateRate, (state, action) => adapter.updateOne(action.rate, state)),

--- a/src/app/core/store/selectors/configuration.selectors.ts
+++ b/src/app/core/store/selectors/configuration.selectors.ts
@@ -1,11 +1,19 @@
-import { createSelector } from '@ngrx/store';
+import { createFeatureSelector, createSelector} from '@ngrx/store';
 import { ConfigurationState } from 'app-core/models/configuration';
-import { AppState } from 'app-core/models/general-state';
 
-export const appConfiguration = (state: AppState): ConfigurationState =>
-  state.configuration;
+export const appConfiguration = createFeatureSelector<ConfigurationState>('configuration')
 
 export const socketStatus = createSelector(
   appConfiguration,
-  (state) => state.websocketConnected
+  state => state.websocketConnected
+);
+
+export const ratesStreamStatus = createSelector(
+  appConfiguration,
+  state => state.ratesStreamStarted
+);
+
+export const openPositionStreamStatus = createSelector(
+  appConfiguration,
+  state => state.openPositionStreamStarted
 );

--- a/src/app/core/store/selectors/router.selectors.ts
+++ b/src/app/core/store/selectors/router.selectors.ts
@@ -1,0 +1,18 @@
+import { getRouterSelectors } from '@ngrx/router-store';
+
+// `router` is used as the default feature name. You can use the feature name
+// of your choice by creating a feature selector and pass it to the `getRouterSelectors` function
+// export const selectRouter = createFeatureSelector<RouterReducerState>('yourFeatureName');
+
+export const {
+  selectCurrentRoute, // select the current route
+  selectFragment, // select the current route fragment
+  selectQueryParams, // select the current route query params
+  selectQueryParam, // factory function to select a query param
+  selectRouteParams, // select the current route params
+  selectRouteParam, // factory function to select a route param
+  selectRouteData, // select the current route data
+  selectRouteDataParam, // factory function to select a route data param
+  selectUrl, // select the current url
+  selectTitle, // select the title if available
+} = getRouterSelectors();

--- a/src/app/core/utils/custom-route.serializer.ts
+++ b/src/app/core/utils/custom-route.serializer.ts
@@ -1,0 +1,23 @@
+import { RouterStateSnapshot } from '@angular/router';
+import { RouterStateSerializer } from '@ngrx/router-store';
+import { RouterStateUrl } from 'app-core/models/router-state.model';
+
+export class CustomSerializer implements RouterStateSerializer<RouterStateUrl> {
+  serialize(routerState: RouterStateSnapshot): RouterStateUrl {
+    let route = routerState.root;
+
+    while (route.firstChild) {
+      route = route.firstChild;
+    }
+
+    const {
+      url,
+      root: { queryParams },
+    } = routerState;
+    const { params } = route;
+
+    // Only return an object including the URL, params and query params
+    // instead of the entire snapshot
+    return { url, params, queryParams };
+  }
+}

--- a/src/app/pages/dashboard/live-quotes/live-quotes.component.ts
+++ b/src/app/pages/dashboard/live-quotes/live-quotes.component.ts
@@ -34,8 +34,6 @@ export class LiveQuotesComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.ratesFacade.loadInitialRates();
-    this.ratesFacade.startRatesStream();
 
     this.ratesFacade
       .getAllRates()

--- a/src/app/pages/dashboard/open-positions/open-positions.component.ts
+++ b/src/app/pages/dashboard/open-positions/open-positions.component.ts
@@ -18,9 +18,6 @@ export class OpenPositionsComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.openPositionsFacade.loadInitialOpenPositions();
-
-    this.openPositionsFacade.startOpenPositionsStream();
 
     this.openPositionsFacade
       .getAllOpenPositions()

--- a/src/app/replacements/store-devtools.module.ts
+++ b/src/app/replacements/store-devtools.module.ts
@@ -1,5 +1,7 @@
 import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 
 export const storeDevtoolsModule = [
-  StoreDevtoolsModule.instrument(),
+  StoreDevtoolsModule.instrument({
+    maxAge: 200,
+  }),
 ];


### PR DESCRIPTION
…ed" checking before subscription for rates and open position. Unsubscription from rates and open positions streams on router events.
 - @ngrx/router-store implementation
 - new configuration effects
 - new "connected socket" check in DataService and start socket implementation in SocketService
 - start rates and open positions streams on url "/dashboard" only in browser
 - stop rates and open position streams on URL, different from "/dashboard" only in browser